### PR TITLE
Made the get started button link to your projects github

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="jumbotron">
   <h1>Lebab modernizes your JavaScript code!</h1>
-  <a href="#get-started" class="get-started">Get started!</a>
+  <a href="https://github.com/lebab/lebab" class="get-started">Get started!</a>
   <iframe class="github-star" src="https://ghbtns.com/github-btn.html?user=mohebifar&amp;repo=lebab&amp;type=star&amp;count=true&amp;size=large" frameborder="0"></iframe>
 </div>
 


### PR DESCRIPTION
I'm sure its just a temporary fix but I noticed the "Get Started" button doesn't go anywhere. For the time being, I've linked it to the Lebab GitHub. 

If you were curious about the second commit, I didn't notice until I looked at the diff that VS Code made a settings file/folder. The second commit was just deleting that folder